### PR TITLE
Fixes to history logic and API.

### DIFF
--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -75,7 +75,7 @@ module {
     };
 
     public func addNfts(caller : Principal, nfts : [Types.Nft.Nft]) : async Bool {
-      let log = logger.Begin(caller, #setNfts(nfts));
+      let log = logger.Begin(caller, #addNfts(nfts));
       for (nft in nfts.vals()) {
         let isOwned = await isNftOwned_(caller, nft);
         log.internal(#verifyOwnerOutcome(nft, isOwned));
@@ -83,8 +83,10 @@ module {
         if (not isOwned) {
           return log.errWith(false);
         };
+        if (state.walletOwnsNft.get(nft.owner, nft) == null) {
+          state.emitAddNftEvent(caller, nft.owner, nft);
+        };
         state.walletOwnsNft.put(nft.owner, nft, { checkTime = sys.time() });
-        state.emitAddNftEvent(caller, nft.owner, nft);
       };
       log.okWith(true);
     };

--- a/canisters/backend/History.mo
+++ b/canisters/backend/History.mo
@@ -14,7 +14,7 @@ module {
     #login;
     #connectEthWallet : (Types.EthWallet, Types.SignedPrincipal);
     #isNftOwned : Types.Nft.Nft;
-    #setNfts : [Types.Nft.Nft];
+    #addNfts : [Types.Nft.Nft];
   };
 
   public type Response = {

--- a/canisters/backend/Main.mo
+++ b/canisters/backend/Main.mo
@@ -42,7 +42,7 @@ shared ({ caller = installer }) actor class Main() {
     core.getNfts(caller);
   };
 
-  public shared ({ caller }) func getHistory() : async ?[History.Event] {
+  public query ({ caller }) func getHistory() : async ?[History.Event] {
     core.getHistory(caller);
   };
 
@@ -50,7 +50,7 @@ shared ({ caller = installer }) actor class Main() {
     core.getPublicHistory(caller);
   };
 
-  public shared ({ caller }) func getState() : async ?[Snapshot.Entry] {
+  public query ({ caller }) func getState() : async ?[Snapshot.Entry] {
     core.getState(caller);
   };
 


### PR DESCRIPTION
- `getPublicHistory` shows the first instance of each NFT (earliest add time), but not later occurrences.
- `getHistory` and `getState` are both `query` functions.
- update to use `#addNfts` in output of `getHistory` (not older `#setNfts`).