### PR TITLE
Add `filterAddress()` method to Motoko backend

### DIFF
--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -105,9 +105,9 @@ module {
       Iter.toArray(nfts);
     };
 
-    public func filterAddress(caller : Principal, address : Types.Address.Address) : async Bool {
+    public func setAddressFiltered(caller : Principal, address : Types.Address.Address, filtered : Bool) : async Bool {
       assert caller == installer;
-      let log = logger.Begin(caller, #filterAddress(address));
+      let log = logger.Begin(caller, #setAddressFiltered(address, filtered));
       state.filteredAddresses.put(address);
       log.okWith(true);
     };

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -107,7 +107,7 @@ module {
 
     public func filterAddress(caller : Principal, address : Types.Address.Address) : async Bool {
       let log = logger.Begin(caller, #filterAddress(address));
-      state.filteredAddresses.put(address, ());
+      state.filteredAddresses.put(address);
       log.okWith(true);
     };
 

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -96,13 +96,7 @@ module {
         func(e : Types.PublicEvent) : ?Types.Nft.Nft {
           switch (e) {
             case (#addNft(e)) {
-              if (
-                e.principal == caller and (
-                  not state.filteredAddresses.has(e.nft.contract)
-                ) and (
-                  not state.filteredAddresses.has(e.nft.owner)
-                )
-              ) ?e.nft else null;
+              if (e.principal == caller) ?e.nft else null;
             };
             case _ null;
           };

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -105,6 +105,12 @@ module {
       Iter.toArray(nfts);
     };
 
+    public func filterAddress(caller : Principal, address : Types.Address.Address) : async Bool {
+      let log = logger.Begin(caller, #filterAddress(address));
+      state.filteredAddresses.put(address, ());
+      log.okWith(true);
+    };
+
     public func getPublicHistory(caller : Principal) : [Types.PublicEvent] {
       Iter.toArray(state.getPublicHistory());
     };

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -108,7 +108,11 @@ module {
     public func setAddressFiltered(caller : Principal, address : Types.Address.Address, filtered : Bool) : async Bool {
       assert caller == installer;
       let log = logger.Begin(caller, #setAddressFiltered(address, filtered));
-      state.filteredAddresses.put(address);
+      if (filtered) {
+        state.filteredAddresses.put(address);
+      } else {
+        state.filteredAddresses.remove(address);
+      };
       log.okWith(true);
     };
 

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -91,12 +91,18 @@ module {
     };
 
     public func getNfts(caller : Principal) : [Types.Nft.Nft] {
-      let nfts = Iter.mapFilter<Types.PublicEvent, Types.Nft.Nft>(
+      let nfts = Iter.filterMap<Types.PublicEvent, Types.Nft.Nft>(
         state.getPublicHistory(),
         func(e : Types.PublicEvent) : ?Types.Nft.Nft {
           switch (e) {
             case (#addNft(e)) {
-              if (e.principal == caller) ?e.nft else null;
+              if (
+                e.principal == caller and (
+                  not state.filteredAddresses.has(e.nft.contract)
+                ) and (
+                  not state.filteredAddresses.has(e.nft.owner)
+                )
+              ) ?e.nft else null;
             };
             case _ null;
           };

--- a/canisters/backend/Core.mo
+++ b/canisters/backend/Core.mo
@@ -112,6 +112,7 @@ module {
     };
 
     public func filterAddress(caller : Principal, address : Types.Address.Address) : async Bool {
+      assert caller == installer;
       let log = logger.Begin(caller, #filterAddress(address));
       state.filteredAddresses.put(address);
       log.okWith(true);

--- a/canisters/backend/History.mo
+++ b/canisters/backend/History.mo
@@ -15,7 +15,7 @@ module {
     #connectEthWallet : (Types.EthWallet, Types.SignedPrincipal);
     #isNftOwned : Types.Nft.Nft;
     #addNfts : [Types.Nft.Nft];
-    #filterAddress : Types.Address.Address;
+    #setAddressFiltered : (Types.Address.Address, Bool);
   };
 
   public type Response = {

--- a/canisters/backend/History.mo
+++ b/canisters/backend/History.mo
@@ -15,6 +15,7 @@ module {
     #connectEthWallet : (Types.EthWallet, Types.SignedPrincipal);
     #isNftOwned : Types.Nft.Nft;
     #addNfts : [Types.Nft.Nft];
+    #filterAddress : Types.Address.Address;
   };
 
   public type Response = {

--- a/canisters/backend/Main.mo
+++ b/canisters/backend/Main.mo
@@ -49,6 +49,11 @@ shared ({ caller = installer }) actor class Main() {
     core.getNfts(caller);
   };
 
+  /// Hides all NFTs with the given smart contract or wallet address.
+  public shared ({ caller }) func filterAddress(address : Types.Address.Address) : async Bool {
+    await core.filterAddress(address);
+  };
+
   /// Retrieve the full log for this canister.
   public query ({ caller }) func getHistory() : async ?[History.Event] {
     core.getHistory(caller);

--- a/canisters/backend/Main.mo
+++ b/canisters/backend/Main.mo
@@ -49,9 +49,9 @@ shared ({ caller = installer }) actor class Main() {
     core.getNfts(caller);
   };
 
-  /// Hides all NFTs with the given smart contract or wallet address.
-  public shared ({ caller }) func filterAddress(address : Types.Address.Address) : async Bool {
-    await core.filterAddress(caller, address);
+  /// Hide or show all NFTs with the given smart contract or wallet address.
+  public shared ({ caller }) func setAddressFiltered(address : Types.Address.Address, filtered : Bool) : async Bool {
+    await core.setAddressFiltered(caller, address, filtered);
   };
 
   /// Retrieve the full log for this canister.

--- a/canisters/backend/Main.mo
+++ b/canisters/backend/Main.mo
@@ -51,7 +51,7 @@ shared ({ caller = installer }) actor class Main() {
 
   /// Hides all NFTs with the given smart contract or wallet address.
   public shared ({ caller }) func filterAddress(address : Types.Address.Address) : async Bool {
-    await core.filterAddress(address);
+    await core.filterAddress(caller, address);
   };
 
   /// Retrieve the full log for this canister.

--- a/canisters/backend/State.mo
+++ b/canisters/backend/State.mo
@@ -153,7 +153,7 @@ module {
             case (#addNft(e)) {
               if (
                 not filteredAddresses.has(e.nft.contract) and not filteredAddresses.has(e.nft.owner)
-              ) ?#addNft(e) else null;
+              ) ? #addNft(e) else null;
             };
             case (e) ?e;
           };

--- a/canisters/backend/State.mo
+++ b/canisters/backend/State.mo
@@ -38,8 +38,8 @@ module {
       //
       principals : Relate.Stable.Map<Principal, CreateSuccess>;
       ethWallets : Relate.Stable.Map<EthWallet, CreateSuccess>;
-
       ethNfts : Relate.Stable.Map<NftId, Nft>;
+      filteredAddresses : Relate.Stable.Map<Address.Address, ()>;
 
       //
       // Relations
@@ -57,6 +57,7 @@ module {
         principals = Relate.Stable.emptyMap();
         ethWallets = Relate.Stable.emptyMap();
         ethNfts = Relate.Stable.emptyMap();
+        filteredAddresses = Relate.Stable.emptyMap();
 
         walletSignsPrincipal = Relate.Stable.emptyTernRel();
         walletOwnsNft = Relate.Stable.emptyTernRel();

--- a/canisters/backend/State.mo
+++ b/canisters/backend/State.mo
@@ -81,6 +81,8 @@ module {
 
     public let ethNfts = Relate.OO.Map<NftId, Nft>(state.ethNfts, NftId.hash, NftId.equal);
 
+    public let filteredAddresses = Relate.OO.UnRel<Address.Address>(state.filteredAddresses, Address.hash, Address.equal);
+
     public let walletSignsPrincipal = Relate.OO.TernRel<EthWallet, Principal, SignatureCheckSuccess>(
       state.walletSignsPrincipal,
       (Address.hash, Principal.hash),

--- a/canisters/backend/State.mo
+++ b/canisters/backend/State.mo
@@ -5,6 +5,7 @@ import Principal "mo:base/Principal";
 import Int "mo:base/Int";
 import Seq "mo:sequence/Sequence";
 import Stream "mo:sequence/Stream";
+import Iter_ "lib/IterMore";
 import Relate "lib/Relate";
 import System "lib/System";
 
@@ -145,7 +146,19 @@ module {
     };
 
     public func getPublicHistory() : Iter.Iter<Types.PublicEvent> {
-      Seq.iter(state.publicHistory.events, #bwd);
+      Iter_.filterMap<Types.PublicEvent, Types.PublicEvent>(
+        Seq.iter(state.publicHistory.events, #bwd),
+        func(e : Types.PublicEvent) : ?Types.PublicEvent {
+          switch (e) {
+            case (#addNft(e)) {
+              if (
+                not filteredAddresses.has(e.nft.contract) and not filteredAddresses.has(e.nft.owner)
+              ) ?#addNft(e) else null;
+            };
+            case (e) ?e;
+          };
+        },
+      );
     };
 
   };

--- a/canisters/backend/lib/IterMore.mo
+++ b/canisters/backend/lib/IterMore.mo
@@ -70,7 +70,7 @@ module {
     };
   };
 
-  public func mapFilter<X, Y>(xs : Iter<X>, f : X -> ?Y) : Iter<Y> {
+  public func filterMap<X, Y>(xs : Iter<X>, f : X -> ?Y) : Iter<Y> {
     object {
       public func next() : ?Y {
         loop {


### PR DESCRIPTION
Enables the installer principal (or moderating SNS, etc.) to filter specific wallet and NFT contract addresses from the public history view.