### PR TITLE
Deactivate idle logout by default

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -26,7 +26,12 @@ export const USER_STORE = makeObservable<User | null | undefined>();
 const localIdentityProvider = `http://localhost:4943?canisterId=${process.env.INTERNET_IDENTITY_CANISTER_ID}`;
 
 const clientPromise = window.indexedDB
-  ? AuthClient.create()
+  ? AuthClient.create({
+      idleOptions: {
+        disableIdle: true,
+        disableDefaultIdleCallback: true,
+      },
+    })
   : Promise.resolve(undefined);
 
 const loginIC = async (


### PR DESCRIPTION
Deactivates the Internet Identity idle logout for improved UX and consistency with the NNS Dapp ([relevant source code](https://github.com/dfinity/nns-dapp/blob/b106bb4ae4002b8e192d89fc769378678886c176/frontend/src/lib/utils/auth.utils.ts#L20-L25)).