### PR TITLE
Use `nat` Candid representation for ERC-1155 `balanceOf` result

### DIFF
--- a/canisters/ic_eth/ic_eth.did
+++ b/canisters/ic_eth/ic_eth.did
@@ -1,5 +1,5 @@
 service : {
   verify_ecdsa : (eth_address : text, message : text, signature : text) -> (bool) query;
   erc721_owner_of : (network : text, contract_address : text, token_id : nat64) -> (text);
-  erc1155_balance_of : (network : text, contract_address : text, owner_address : text, token_id : nat64) -> (nat64);
+  erc1155_balance_of : (network : text, contract_address : text, owner_address : text, token_id : nat64) -> (nat);
 }

--- a/canisters/ic_eth/src/lib.rs
+++ b/canisters/ic_eth/src/lib.rs
@@ -60,9 +60,7 @@ pub async fn erc1155_balance_of(
     contract_address: String,
     owner_address: String,
     token_id: u64,
-) -> u64 {
-    // TODO: use `candid::Nat` in place of `u64`
-
+) -> u128 {
     let owner_address =
         ethers_core::types::Address::from_str(&owner_address).expect("Invalid owner address");
 
@@ -79,7 +77,7 @@ pub async fn erc1155_balance_of(
     )
     .await;
     match result.get(0) {
-        Some(Token::Uint(n)) => n.as_u64(),
+        Some(Token::Uint(n)) => n.as_u128(),
         _ => panic!("Unexpected result"),
     }
 }


### PR DESCRIPTION
Increases the precision of multi-token balances from 64 to 128 bits.